### PR TITLE
 #!/bin/bash is a safer option (broader compatibility)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 PRINT_RED='\033[0;31m'
 PRINT_RESET='\033[0m'
 


### PR DESCRIPTION
`#!/bin/bash `– Specifies that the script should run using the Bash shell. This is the most common choice since Bash is the default shell on many Linux systems.

Zsh is a more advanced shell with additional features, but it is not always installed by default.

Since your script not uses Zsh-specific features, then `#!/bin/bash` is the correct choice