### PR TITLE
Removing without exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ oradata_old
 ords-config
 ords-secrets
 .env
+.env.bak
 .env_old
 .env.ords
 **/cert.crt
@@ -12,3 +13,4 @@ apex/**/*
 META-INF/**/*
 apex-images
 install_*.log
+.fetch-client/

--- a/docs/src/content/docs/getting-started/creating-users.mdx
+++ b/docs/src/content/docs/getting-started/creating-users.mdx
@@ -36,7 +36,7 @@ This will:
 If you only need a database schema without an APEX workspace:
 
 ```bash
-local-26ai.sh create-user myschema --skip_workspace
+local-26ai.sh create-user myschema --skip-workspace
 ```
 
 ### Clear a Schema

--- a/scripts/after-first-db-start.sh
+++ b/scripts/after-first-db-start.sh
@@ -74,7 +74,7 @@ SQL
 read -r -p "Enter the APEX Internal ADMIN password [Welcome_1]: " ADMIN_PWD
 ADMIN_PWD=${ADMIN_PWD:-Welcome_1}
 echo "Changing Internal ADMIN password to $ADMIN_PWD"
-echo -e "ADMIN\nADMIN\n$ADMIN_PWD" | sql -name "$DB_CONN_NAME" @apxchpwd.sql
+echo -e "ADMIN\nADMIN\n$ADMIN_PWD" | sql -name "$DB_CONN_NAME" @apex/apxchpwd.sql
 
 ./scripts/sync-backups-folder.sh
 

--- a/scripts/drop-user.sh
+++ b/scripts/drop-user.sh
@@ -22,9 +22,16 @@ if [[ $answer == "y" ]] || [[ $answer == "Y" ]]; then
 
   sql -name $DB_CONN_NAME <<SQL
     select user from dual;
-
+    set serveroutput on size 1000000 format wrapped
+    declare
+       e_no_workspace exception;
+       pragma exception_init (e_no_workspace, -20987);
     begin
       APEX_INSTANCE_ADMIN.REMOVE_WORKSPACE('${USERNAME_UPPER}');
+    exception
+      when e_no_workspace
+      then
+        sys.dbms_output.put_line ('No Workspace to be removed');
     end;
     /
 

--- a/scripts/sql/drop_all.sql
+++ b/scripts/sql/drop_all.sql
@@ -40,6 +40,12 @@ BEGIN
            continue;
         end if;
         --
+        if cur_rec.object_type = 'SCHEDULE'
+        then
+          execute IMMEDIATE 'begin sys.dbms_scheduler.drop_schedule (schedule_name => '''||cur_rec.object_name||''', force => true); end;';
+          continue;
+        end if;
+        --
         IF cur_rec.object_type = 'TABLE' THEN
           l_cascade := ' CASCADE CONSTRAINTS';
         END IF;

--- a/scripts/sql/drop_apex_apps.sql
+++ b/scripts/sql/drop_apex_apps.sql
@@ -1,3 +1,6 @@
+declare
+  e_no_workspace exception;
+  pragma exception_init (e_no_workspace, -20987);
 begin
   apex_application_install.set_workspace(user);
   apex_application_install.set_keep_sessions(false);
@@ -10,6 +13,9 @@ begin
     dbms_output.put_line('Removing application ' || rec.application_id);
     apex_application_install.remove_application(rec.application_id);
   end loop;
-
+exception
+  when e_no_workspace
+  then 
+    sys.dbms_output.put_line ('No APEX Workspace with name: '||user);
 end;
 /


### PR DESCRIPTION
For removing objects or dropping a schema:
When there is no workspace, the exception is unhandled instead of letting it propagate out.

Small typo is the usage of skipping workspace.

A call to apxchpwd.sql was incorrect