### PR TITLE
Fix DB healthcheck so it works under Podman

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - oradata-26ai:/opt/oracle/oradata
     restart: no
     healthcheck:
-      #test: ["CMD", "healthcheck.sh"]
+      test: ["CMD-SHELL", "/opt/oracle/checkDBStatus.sh >/dev/null 2>&1 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Problem

Following the project's Podman-on-macOS setup guide (brew-installed Podman + `podman compose` with the docker-compose provider), `install.sh` / `local-26ai.sh start` fails: the `26ai` container is never created, so ORDS (`depends_on: condition: service_healthy`) never starts either.

```
Error response from daemon: fill out specgen: must define a healthcheck command for all healthchecks
```

## Root cause

`docker-compose.yml` declares a `healthcheck:` block with the `test` line commented out. On Docker this works — the engine falls back to the image's built-in `HEALTHCHECK` and the block merely tunes the timing. Podman's specgen, however, rejects a healthcheck config that has options but no command. The Podman leg of CI (ubuntu-latest's preinstalled Podman) happens to tolerate it, which is why CI stays green — but current Podman on macOS (6.0.1 via Homebrew, docker-compose provider 5.0.2) does not.

Minimal reproduction — `podman compose up -d` with the healthcheck block copied verbatim:

```yaml
services:
  hc:
    image: container-registry.oracle.com/database/free:23.26.2.0
    entrypoint: ["sleep", "300"]
    healthcheck:
      #test: ["CMD", "healthcheck.sh"]
      interval: 10s
      timeout: 5s
      retries: 10
      start_period: 5s
```

## Fix

Define the test explicitly, pointing at the script the image actually ships (`checkDBStatus.sh` — the commented-out `healthcheck.sh` doesn't exist in the image):

```yaml
test: ["CMD-SHELL", "/opt/oracle/checkDBStatus.sh >/dev/null 2>&1 || exit 1"]
```

I've been running this for weeks on Podman/macOS; it works unchanged on Docker as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
